### PR TITLE
Add actions, remove calculated state, fix unpack order

### DIFF
--- a/packages/auth-components/src/index.ts
+++ b/packages/auth-components/src/index.ts
@@ -1,6 +1,6 @@
 import { hyperStyled } from "@macrostrat/hyper";
 import { Button, IconName } from "@blueprintjs/core";
-import { LoginForm } from "./login-form";
+import { LogoutForm } from "./login-form";
 import { useAuth } from "./context";
 import styles from "./main.module.styl";
 const h = hyperStyled(styles);
@@ -11,19 +11,21 @@ function AuthStatus(props) {
 
   let text = "Not logged in";
   let icon: IconName = "blocked-person";
+  let action: () => void = () => runAction({ type: "login" });
   if (user != null) {
     text = "Logged in";
     icon = "person";
+    action = () => runAction({ type: "request-form" });
   }
   return h("div.auth-status", { className }, [
-    h(LoginForm),
+    h(LogoutForm),
     h(
       Button,
       {
         minimal: true,
         large,
         icon,
-        onClick: () => runAction({ type: "request-form" }),
+        onClick: action,
       },
       showText ? text : null
     ),

--- a/packages/auth-components/src/login-form.ts
+++ b/packages/auth-components/src/login-form.ts
@@ -76,6 +76,7 @@ function CredentialsDialog({
 }
 
 function LogoutForm({ serverStatusComponent = null }) {
+
   const { runAction, user, userIdentity } = useAuth();
   const actionButtons = h([
     h.if(serverStatusComponent != null)(serverStatusComponent),
@@ -164,8 +165,8 @@ function _LoginForm() {
 }
 
 function LoginForm() {
-  const { login } = useAuth();
-  return login ? h(LogoutForm) : h(_LoginForm);
+  const { user } = useAuth();
+  return user != null ? h(LogoutForm) : h(_LoginForm);
 }
 
-export { LoginForm };
+export { LogoutForm };


### PR DESCRIPTION
- Add/Update actions to update a user and logout
- Remove login which seemed to be in all cases user != null, which made it harder to manage
- Move the unpack of state to the end so it is prioritized over state passed into the Auth Context. This resulted in a bug where user never changed past what it was initialized as.