### PR TITLE
Fix Node compilation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" default="true">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myRunOnSave" value="true" />
+    <option name="myRunOnReformat" value="true" />
+    <option name="myFilesPattern" value="**/*.{js,ts,jsx,tsx,cjs,cts,mjs,mts,vue,astro,json,md,mdx}" />
+    <option name="formatFilesOutsideDependencyScope" value="false" />
+  </component>
+</project>

--- a/packages/column-components/CHANGELOG.md
+++ b/packages/column-components/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-02-15
+
+Add a `node` target to bundle without imported CSS
+
 ## [1.0.1] - 2025-02-14
 
 - Update d3 dependencies to [v6](https://observablehq.com/@d3/d3v6-migration-guide)

--- a/packages/column-components/package.json
+++ b/packages/column-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/column-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "React rendering primitives for stratigraphic columns",
   "keywords": [
     "geology",
@@ -8,18 +8,27 @@
     "vector-graphics",
     "data-visualization"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/esm/index.js",
   "type": "module",
   "source": "./src/index.ts",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
+  "node": "./dist/node/index.js",
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
     },
     "./stories/base-section": {
       "source": "./stories/base-section.ts"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "files": [

--- a/packages/column-views/CHANGELOG.md
+++ b/packages/column-views/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-02-15
+
+Add a `node` target to bundle without imported CSS
+
 ## [1.0.0] - 2025-02-14
 
 - First full release of the `@macrostrat/column-views` library

--- a/packages/column-views/package.json
+++ b/packages/column-views/package.json
@@ -1,19 +1,28 @@
 {
   "name": "@macrostrat/column-views",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Data views for Macrostrat stratigraphic columns",
-  "main": "dist/index.js",
   "type": "module",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
   "sideEffects": [
     "**/*.css"
   ],
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "scripts": {

--- a/packages/data-components/CHANGELOG.md
+++ b/packages/data-components/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.6] - 2025-02-14
+
+Add `node` target to bundle without imported CSS
+
 ## [0.0.5] - 2025-01-04
 
 - Migrate from `vx` to `visx` for charts

--- a/packages/data-components/package.json
+++ b/packages/data-components/package.json
@@ -1,11 +1,27 @@
 {
   "name": "@macrostrat/data-components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A library of react components tailored for Macrostrat data and endpoints",
   "type": "module",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
   "scripts": {
     "dev": "parcel watch",
     "build": "rm -rf dist && parcel build"
@@ -18,12 +34,9 @@
   "devDependencies": {
     "@blueprintjs/core": "^5.10.2",
     "@types/d3-array": "^3",
-    "@types/prop-types": "^15",
-    "parcel": "^2.13.3",
-    "prop-types": "^15.8.1"
+    "parcel": "^2.13.3"
   },
   "peerDependencies": {
-    "@blueprintjs/core": "^5.0.0",
     "react": "^16.8.6||^17.0.2||^18"
   },
   "dependencies": {
@@ -42,12 +55,5 @@
   "files": [
     "src",
     "dist"
-  ],
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  }
+  ]
 }

--- a/packages/data-components/package.json
+++ b/packages/data-components/package.json
@@ -37,6 +37,7 @@
     "parcel": "^2.13.3"
   },
   "peerDependencies": {
+    "@blueprintjs/core": "^5.10.2",
     "react": "^16.8.6||^17.0.2||^18"
   },
   "dependencies": {

--- a/packages/data-sheet/CHANGELOG.md
+++ b/packages/data-sheet/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+All notable changes to this project will be documented in this file. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.1] - 2025-02-15
+
+Add a `node` target to bundle without imported CSS
 
 ## [2.0.0] - 2025-02-14
 
-- New version of the `@macrostrat/data-sheet` library based on `@blueprintjs/table` and `@blueprintjs/core`
+- New version of the `@macrostrat/data-sheet` library based on
+  `@blueprintjs/table` and `@blueprintjs/core`
 - Full-featured and customizable virtualized data sheet
-- Preliminary support for windowed loading and [PostgREST](https://postgrest.org) data fetching
+- Preliminary support for windowed loading and
+  [PostgREST](https://postgrest.org) data fetching
 - Standardized approach to tooltips, context menus, and other controls
 
 ## [1.0.0] - 2021 to 2024
 
-- Initial release of the `@macrostrat/data-sheet` library based on `react-datasheet`
+- Initial release of the `@macrostrat/data-sheet` library based on
+  `react-datasheet`

--- a/packages/data-sheet/package.json
+++ b/packages/data-sheet/package.json
@@ -1,11 +1,27 @@
 {
   "name": "@macrostrat/data-sheet",
-  "version": "2.0.0",
-  "description": "",
-  "source": "src/index.ts",
-  "main": "dist/index.js",
+  "version": "2.0.1",
+  "description": "Scalable data sheet with optional editing capabilities",
   "type": "module",
-  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
   "scripts": {
     "build": "rm -rf dist && parcel build"
   },
@@ -26,13 +42,6 @@
     "react-colorful": "^5.6.1",
     "underscore": "^1.13.7",
     "zustand": "^5.0.2"
-  },
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
   },
   "files": [
     "src",

--- a/packages/feedback-components/CHANGELOG.md
+++ b/packages/feedback-components/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+All notable changes to this project will be documented in this file. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2025-02-15
+
+Added a `node` target to bundle without imported CSS.
 
 ## [1.0.0] - 2025-02-14
 
-First public release of the `@macrostrat/feedback-components` library,
-focused on text feedback for Macrostrat unit information.
+First public release of the `@macrostrat/feedback-components` library, focused
+on text feedback for Macrostrat unit information.

--- a/packages/feedback-components/package.json
+++ b/packages/feedback-components/package.json
@@ -1,11 +1,31 @@
 {
   "name": "@macrostrat/feedback-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "source": "src/index.ts",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
   "scripts": {
     "build": "rm -rf dist && parcel build"
   },
@@ -25,13 +45,6 @@
     "react-arborist": "^3.4.0",
     "react-text-annotate-blend": "^1.2.0",
     "use-element-dimensions": "^2.1.3"
-  },
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
   },
   "peerDependencies": {
     "react": "^17.0.2||^18",

--- a/packages/form-components/CHANGELOG.md
+++ b/packages/form-components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1] - 2025-02-15
+
+Addd a `node` target to bundle without imported CSS.
+
 ## [0.1.0] - 2025-02-14
 
 - Added authentication components to the initial form components from Sparrow

--- a/packages/form-components/package.json
+++ b/packages/form-components/package.json
@@ -1,7 +1,26 @@
 {
   "name": "@macrostrat/form-components",
-  "version": "0.1.0",
-  "description": "A react library",
+  "version": "0.1.1",
+  "description": "Form components for user input into Macrostrat apps",
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
   "scripts": {
     "build": "rm -rf dist && parcel build"
   },
@@ -37,21 +56,6 @@
     "axios": "^1.7.9",
     "classnames": "^2.5.1",
     "mapbox-gl": "^2.15.0"
-  },
-  "type": "module",
-  "source": "src/index.ts",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "src",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
   },
   "repository": {
     "type": "git",

--- a/packages/map-interface/CHANGELOG.md
+++ b/packages/map-interface/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-02-15
+
+Add a `node` target to bundle without imported CSS
+
 ## [1.2.0] - 2025-02-14
 
 - Make several dependencies more explicit

--- a/packages/map-interface/package.json
+++ b/packages/map-interface/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@macrostrat/map-interface",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Map interface for Macrostrat",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
+  "node": "/dist/node/index.js",
   "dependencies": {
     "@blueprintjs/core": "^5.0.0",
     "@macrostrat/color-utils": "workspace:^",
@@ -40,7 +41,15 @@
       "source": "./src/index.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "files": [

--- a/packages/svg-map-components/CHANGELOG.md
+++ b/packages/svg-map-components/CHANGELOG.md
@@ -1,40 +1,45 @@
-## Changelog
+# Changelog
 
-### [1.0.2] - 2025-02-14
+## [1.0.3] - 2025-02-15
+
+Add `node` target to bundle without imported CSS.
+
+## [1.0.2] - 2025-02-14
 
 - Fix an issue with map sizing (height was mistakenly set to width).
-- Upgrade D3 dependencies to latest [v6](https://observablehq.com/@d3/d3v6-migration-guide) versions 
+- Upgrade D3 dependencies to latest
+  [v6](https://observablehq.com/@d3/d3v6-migration-guide) versions
 
-### [1.0.1] - 2025-02-14
+## [1.0.1] - 2025-02-14
 
 - Added `src` files to deployment package.
 
-### [1.0.0] - 2025-02-04
+## [1.0.0] - 2025-02-04
 
 - Renamed to `@macrostrat/svg-map-components` to avoid confusion with other map
   libraries.
 - Moved some UI components to `@macrostrat/ui-components` package.
 - Improved typings and documentation.
 
-### [0.2.1]
+## [0.2.1]
 
 - Add better state handling and ability to reset projection.
 - Last release as `@macrostrat/map-components`
 
-### [0.2.0] August 2020
+## [0.2.0] August 2020
 
 - Improve typings
 - Fix bug with projection clipping and `Sphere` geometry.
 
-### April 2020
+## April 2020
 
 - Complete move towards typescript
 - Update bundler strategy
 
-### December 2019
+## December 2019
 
 - Initial vendorization of library for use in column renderer widget
 
-### Summer 2019
+## Summer 2019
 
 - Code created as part of `corelle` project

--- a/packages/svg-map-components/package.json
+++ b/packages/svg-map-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/svg-map-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React components for vector maps",
   "keywords": [
     "gis",
@@ -8,10 +8,26 @@
     "maps",
     "vector-graphics"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "type": "module",
   "source": "src/index.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
   "files": [
     "src",
     "dist"
@@ -48,13 +64,6 @@
   "peerDependencies": {
     "react": "^16.11.0||^17.0.0||^18.0.0",
     "react-dom": "^16.11.0||^17.0.0||^18.0.0"
-  },
-  "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
   },
   "devDependencies": {
     "parcel": "^2.13.3"

--- a/packages/timescale/CHANGELOG.md
+++ b/packages/timescale/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2025-02-14
+## [2.1.1] - 2025-02-15
+
+Add a `node` target to bundle without imported CSS.
+
+## [2.1.0] - 2025-02-14
 
 - Major update to the timescale component
 - Improved typings and styling somewheat

--- a/packages/timescale/package.json
+++ b/packages/timescale/package.json
@@ -1,16 +1,25 @@
 {
   "name": "@macrostrat/timescale",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A configurable geologic timescale written with React and Typescript",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "source": "src/index.ts",
   "type": "module",
+  "source": "src/index.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "files": [

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.1.1] - 2025-02-15
+
+- Add a `node` target to bundle without imported CSS
+- Move from `typescript` to `source` export in `package.json`
+
 ## [4.1.0] - 2025-02-14
 
 - New compilation pipeline

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [4.1.1] - 2025-02-15
 
-- Add a `node` target to bundle without imported CSS
+- Add a `node` target to bundle without imported CSS. This is a stopgap measure
+  until we can figure out how to handle CSS imports in a more general way.
 - Move from `typescript` to `source` export in `package.json`
 
 ## [4.1.0] - 2025-02-14

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,17 +1,26 @@
 {
   "name": "@macrostrat/ui-components",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "UI components for React and Blueprint.js",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "node": "dist/node/index.js",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "typescript": "./src",
+      "source": "./src/index.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "types": "./dist/esm/index.d.ts",
+      "node": "./dist/node/index.js"
+    }
+  },
+  "targets": {
+    "node": {
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,7 +2594,6 @@ __metadata:
     "@macrostrat/stratigraphy-utils": "workspace:^"
     "@macrostrat/ui-components": "workspace:^"
     "@types/d3-array": "npm:^3"
-    "@types/prop-types": "npm:^15"
     "@visx/axis": "npm:^3.12.0"
     "@visx/gradient": "npm:^3.12.0"
     "@visx/scale": "npm:^3.12.0"
@@ -2603,9 +2602,8 @@ __metadata:
     classnames: "npm:^2.5.1"
     d3-array: "npm:^3.2.4"
     parcel: "npm:^2.13.3"
-    prop-types: "npm:^15.8.1"
   peerDependencies:
-    "@blueprintjs/core": ^5.0.0
+    "@blueprintjs/core": ^5.10.2
     react: ^16.8.6||^17.0.2||^18
   languageName: unknown
   linkType: soft
@@ -5671,7 +5669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15":
+"@types/prop-types@npm:*":
   version: 15.7.14
   resolution: "@types/prop-types@npm:15.7.14"
   checksum: 10c0/1ec775160bfab90b67a782d735952158c7e702ca4502968aa82565bd8e452c2de8601c8dfe349733073c31179116cf7340710160d3836aa8a1ef76d1532893b1


### PR DESCRIPTION
Add a `node` compilation target to all modules that bundle CSS, as a stopgap for consistent handling of stylesheets.

Standalone stylesheet handling may require using Vite or Rollup instead of Parcel.