### PR TITLE
Postgrest scroll 4.3.8

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -5,6 +5,7 @@
 For PostgRESTInfiniteScrollView
 
 - Error handling for newKey
+- Allow inputted searchColumns
 
 ## [4.3.7] - 2025-07-09
 

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.3.8] - 2025-07-09
+
+For PostgRESTInfiniteScrollView
+
+- Error handling for newKey
+
 ## [4.3.7] - 2025-07-09
 
 For PostgRESTInfiniteScrollView

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/ui-components",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "UI components for React and Blueprint.js",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-components/src/postgrest-infinite-scroll.ts
+++ b/packages/ui-components/src/postgrest-infinite-scroll.ts
@@ -14,6 +14,7 @@ interface PostgRESTInfiniteScrollProps extends InfiniteScrollProps<any> {
   extraParams?: Record<string, any>;
   ascending?: boolean;
   filterable?: boolean;
+  searchColumns?: string[];
   order_key?: string;
   key?: string;
   toggles?: any;
@@ -52,6 +53,7 @@ export function PostgRESTInfiniteScrollView(
     extraParams = {},
     key,
     toggles = null,
+    searchColumns = undefined,
     ...rest
   } = props;
 
@@ -64,7 +66,7 @@ export function PostgRESTInfiniteScrollView(
   const MultiSelectToUse = MultiSelectComponent ?? MultiSelect;
 
   const res = useAPIResult(route, { limit: 1 });
-  const [selectedItems, setSelectedItems] = useState<string[]>([]);
+  const [selectedItems, setSelectedItems] = useState<string[]>(searchColumns || []);
   const [filterValue, setFilterValue] = useState<string>("");
   const operator1 = ascending ? `asc` : `desc`;
   const notOperator1 = ascending ? `desc` : `asc`;
@@ -122,7 +124,7 @@ export function PostgRESTInfiniteScrollView(
     return h(Spinner);
   }
 
-  const keys = Object.keys(res[0] || {}).filter(
+  const keys = searchColumns || Object.keys(res[0] || {}).filter(
     (key) => typeof res[0][key] === "string",
   );
 

--- a/packages/ui-components/src/postgrest-infinite-scroll.ts
+++ b/packages/ui-components/src/postgrest-infinite-scroll.ts
@@ -198,8 +198,16 @@ export function PostgRESTInfiniteScrollView(
     });
   };
 
+   const {
+    toggles: _omitToggles,
+    SearchBarComponent: _omitSearchBar,
+    MultiSelectComponent: _omitMultiSelect,
+    ...cleaned
+  } = props;
+
+
   const newKey =
-    key || `${filterValue}-${selectedItems.join(",")}-${JSON.stringify(props)}`;
+    key || `${filterValue}-${selectedItems.join(",")}-${JSON.stringify(cleaned)}`;
 
   return h("div.postgrest-infinite-scroll", [
     h('div.header', [

--- a/packages/ui-components/stories/postgrest-infinite-scroll.stories.ts
+++ b/packages/ui-components/stories/postgrest-infinite-scroll.stories.ts
@@ -25,4 +25,5 @@ Primary.args = {
   route: "https://dev.macrostrat.org/api/pg/sources_metadata",
   delay: 100,
   toggles: h("h1", "Toggles here"),
+  searchColumns: ["name"],
 };


### PR DESCRIPTION
- Error handling for newKey
- Allow inputted searchColumns
