### PR TITLE
feedback-components: fix autoSelect being cleared on mount under StrictMode

### DIFF
--- a/.changeset/feedback-strictmode-autoselect.md
+++ b/.changeset/feedback-strictmode-autoselect.md
@@ -1,5 +1,0 @@
----
-"@macrostrat/feedback-components": patch
----
-
-Fix `autoSelect` being cleared on mount under React StrictMode. 2.3.0's "new input replaces the working tree" effect used a first-run ref flag, but StrictMode invokes an effect, cleans it up, and invokes it again on mount — so the second invocation replaced the tree and discarded the mount-time selection. The effect now compares the tree identity it last rendered, which is idempotent under double invocation.

--- a/.changeset/feedback-strictmode-autoselect.md
+++ b/.changeset/feedback-strictmode-autoselect.md
@@ -1,0 +1,5 @@
+---
+"@macrostrat/feedback-components": patch
+---
+
+Fix `autoSelect` being cleared on mount under React StrictMode. 2.3.0's "new input replaces the working tree" effect used a first-run ref flag, but StrictMode invokes an effect, cleans it up, and invokes it again on mount — so the second invocation replaced the tree and discarded the mount-time selection. The effect now compares the tree identity it last rendered, which is idempotent under double invocation.

--- a/packages/feedback-components/CHANGELOG.md
+++ b/packages/feedback-components/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.3.1] - 2026-09-04 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/feedback-components-v2.3.0...@macrostrat/feedback-components-v2.3.1)
+
+### Patch Changes
+
+- Fix `autoSelect` being cleared on mount under React StrictMode. 2.3.0's "new
+  input replaces the working tree" effect used a first-run ref flag, but
+  StrictMode invokes an effect, cleans it up, and invokes it again on mount — so
+  the second invocation replaced the tree and discarded the mount-time
+  selection. The effect now compares the tree identity it last rendered, which
+  is idempotent under double invocation.
+  [0f5abd66](https://github.com/UW-Macrostrat/web-components/commit/0f5abd661d3729bdd7c861e0e2c1d2301d24e1ce)
+
 ## [2.3.0] - 2026-09-04 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/feedback-components-v2.2.6...@macrostrat/feedback-components-v2.3.0)
 
 ### Minor Changes

--- a/packages/feedback-components/package.json
+++ b/packages/feedback-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/feedback-components",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/feedback-components/src/feedback/index.ts
+++ b/packages/feedback-components/src/feedback/index.ts
@@ -123,12 +123,16 @@ export function FeedbackComponent({
 
   // New input (another run, or reloaded data) replaces the working tree, so a
   // consumer need not remount the component per run.
-  const isFirstTree = useRef(true);
+  //
+  // Keyed on the tree we last rendered, not on a "first run" flag: under
+  // StrictMode an effect is invoked, cleaned up, and invoked again on mount, so
+  // a flag consumed by the first invocation makes the second one replace the
+  // tree — discarding the mount-time state, including any `autoSelect`.
+  // Comparing identities makes the effect idempotent.
+  const renderedTree = useRef(initialTree);
   useEffect(() => {
-    if (isFirstTree.current) {
-      isFirstTree.current = false;
-      return;
-    }
+    if (renderedTree.current === initialTree) return;
+    renderedTree.current = initialTree;
     dispatch({ type: "replace-tree", payload: { tree: initialTree } });
   }, [initialTree]);
 


### PR DESCRIPTION
## Summary

Patch fix for a regression in 2.3.0, found while integrating that release into the web app (UW-Macrostrat/web#425).

2.3.0 added an effect so new `entities` replace the working tree without the consumer remounting the component. It guarded against firing on mount with a first-run ref flag:

```ts
const isFirstTree = useRef(true);
useEffect(() => {
  if (isFirstTree.current) { isFirstTree.current = false; return; }
  dispatch({ type: "replace-tree", payload: { tree: initialTree } });
}, [initialTree]);
```

Under React StrictMode an effect is invoked, cleaned up, and invoked again on mount. The first invocation consumes the flag, so the **second one replaces the tree** — discarding the mount-time state, including the `autoSelect` selection. The effect now compares the tree identity it last rendered, which is idempotent under double invocation.

## Why it matters

`vike-react` enables StrictMode by default (`reactStrictMode !== false`), so this hit the Macrostrat web app in dev: `?autoselect=…` deep-links from the lexicon's "view source" links selected nothing, and the new merge affordance — which only appears with two or more entities selected — never appeared at all.

## Verification

- `yarn run check-types`: clean.
- `yarn workspace @macrostrat/feedback-components run build`: succeeds.
- End-to-end in the web app against a local PostgREST fixture, with the rebuilt `dist` swapped into the installed package: with StrictMode at the app's default (on), `?autoselect=Sandstone,shale` now selects both entities and "Merge 2 entities" renders. Confirmed the same page with StrictMode disabled worked before the fix and with it — i.e. the fix removes the StrictMode dependence rather than masking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SF8Q269wUhcYVNSQXW9y7E

---
_Generated by [Claude Code](https://claude.ai/code/session_01SF8Q269wUhcYVNSQXW9y7E)_