### PR TITLE
Release data-sheet@4.7.0

### DIFF
--- a/.changeset/seeded-first-window.md
+++ b/.changeset/seeded-first-window.md
@@ -1,0 +1,6 @@
+---
+"@macrostrat/data-sheet": minor
+---
+
+- `initialData` now seeds the store at creation, so the first window is in the first render (server renders included) instead of arriving in an effect
+- Provider-backed views no longer have their `data` reset by the provider's init effect; only an in-memory `data` prop is placed there

--- a/.changeset/seeded-first-window.md
+++ b/.changeset/seeded-first-window.md
@@ -1,6 +1,0 @@
----
-"@macrostrat/data-sheet": minor
----
-
-- `initialData` now seeds the store at creation, so the first window is in the first render (server renders included) instead of arriving in an effect
-- Provider-backed views no longer have their `data` reset by the provider's init effect; only an in-memory `data` prop is placed there

--- a/packages/data-sheet/CHANGELOG.md
+++ b/packages/data-sheet/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.7.0] - 2026-09-06 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-sheet-v4.6.0...@macrostrat/data-sheet-v4.7.0)
+
+### Minor Changes
+
+- - `initialData` now seeds the store at creation, so the first window is in the
+    first render (server renders included) instead of arriving in an effect
+    [7baab3c0](https://github.com/UW-Macrostrat/web-components/commit/7baab3c00362e92f1d2621c45ebdde4811fd73b0)
+  - Provider-backed views no longer have their `data` reset by the provider's
+    init effect; only an in-memory `data` prop is placed there
+
 ## [4.6.0] - 2026-09-02 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-sheet-v4.5.2...@macrostrat/data-sheet-v4.6.0)
 
 ### Minor Changes

--- a/packages/data-sheet/package.json
+++ b/packages/data-sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/data-sheet",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Scalable data sheet with optional editing capabilities",
   "repository": {
     "type": "git",

--- a/packages/data-sheet/src/postgrest-table/data-loaders.ts
+++ b/packages/data-sheet/src/postgrest-table/data-loaders.ts
@@ -22,19 +22,13 @@ import {
   useSelector,
 } from "../provider";
 import { atom } from "jotai";
-import { FetchDataOptions, FetchMode, InitialDataChunk } from "../types.ts";
-
-interface LazyLoaderStateCore<T> {
-  loading: boolean;
-  error: Error | null;
-  initialized: boolean;
-  /** Reported source length when known (null = unknown / not reported). */
-  totalCount: number | null;
-  /** Windowing style: infinite-scroll windows, or one fixed page at a time. */
-  fetchMode: FetchMode;
-  /** Rows per chunk/page. */
-  pageSize: number;
-}
+import { FetchDataOptions, FetchMode } from "../types.ts";
+import {
+  lazyLoaderCoreStateAtom,
+  resolveInitialData,
+  seededRows,
+  type LazyLoaderStateCore,
+} from "../provider/loader-state.ts";
 
 interface LazyLoaderState<T> extends LazyLoaderStateCore<T> {
   data: (T | null)[];
@@ -205,10 +199,10 @@ function lazyLoadingReducer<T>(
       // completed first fetch: pre-size to the reported total so the scrollbar
       // and counter are right immediately, and mark the loader `initialized` so
       // it neither refetches the seeded window nor flashes an empty state.
-      const rows = action.data ?? [];
-      const size = Math.max(action.totalCount ?? rows.length, rows.length);
-      const data: (T | null)[] = new Array(size).fill(null);
-      for (let i = 0; i < rows.length; i++) data[i] = rows[i];
+      const data = seededRows({
+        rows: action.data ?? [],
+        totalCount: action.totalCount,
+      });
       return {
         visibleRegion: defaultVisibleRegion,
         data: data as T[],
@@ -373,14 +367,6 @@ const defaultVisibleRegion: RowRegion = {
 /** Atom to house the current visible region of the table */
 const visibleRegionAtom = atom<RowRegion>(defaultVisibleRegion);
 
-const lazyLoaderCoreStateAtom = atom<LazyLoaderStateCore<any>>({
-  loading: false,
-  error: null,
-  initialized: false,
-  totalCount: null,
-  fetchMode: "scroll",
-  pageSize: 100,
-});
 
 /** Current page index (0-based) for paged fetch mode. */
 export const chunkPageAtom = atom(0);
@@ -736,6 +722,10 @@ export function useDataLoader<T = any>(
   // A caller-supplied first window (`initialData`) stands in for the mount-time
   // reset+fetch. It's consumed once: any later view change resets normally,
   // since the seed only describes the view it was fetched for.
+  //
+  // The store is normally created already seeded (`DataSheetStoreWrapper`), so
+  // the rows are in the very first render — including a server render. The
+  // dispatch below is the fallback for a store that wasn't.
   const seedRef = useRef(resolveInitialData(initialData));
   // Gate on the seed until it's actually in state (see the fetch effect).
   const awaitingSeedRef = useRef(seedRef.current != null);
@@ -743,7 +733,13 @@ export function useDataLoader<T = any>(
     const seed = seedRef.current;
     seedRef.current = null;
     if (seed != null) {
-      dispatch({ type: "seed", data: seed.rows, totalCount: seed.totalCount });
+      if (!state.initialized) {
+        dispatch({
+          type: "seed",
+          data: seed.rows,
+          totalCount: seed.totalCount,
+        });
+      }
       setPage(0);
       // Paged mode tracks which (page, view) it has in hand separately from the
       // array; record the seed there too, or it would immediately re-fetch the
@@ -854,21 +850,6 @@ export function useDataLoader<T = any>(
 
 /** A value that trails `value` by `delay` ms of stability — the first value is
  * returned immediately, and `delay <= 0` disables debouncing entirely. */
-/** Normalize the two accepted `initialData` shapes (bare rows, or rows with a
- * total) to one. An empty seed is treated as no seed — there'd be nothing to
- * show and nothing saved. */
-function resolveInitialData<T>(
-  initialData: FetchDataOptions<T>["initialData"],
-): InitialDataChunk<T> | null {
-  if (initialData == null) return null;
-  if (Array.isArray(initialData)) {
-    if (initialData.length === 0) return null;
-    return { rows: initialData };
-  }
-  if ((initialData.rows ?? []).length === 0) return null;
-  return initialData;
-}
-
 function useDebouncedValue<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {

--- a/packages/data-sheet/src/provider/core.ts
+++ b/packages/data-sheet/src/provider/core.ts
@@ -41,7 +41,16 @@ import {
   resolveInteractionOptions,
 } from "./interactions.ts";
 import { DataViewProps } from "../data-view.ts";
-import { DataSheetProps, DataViewCoreProps } from "../types.ts";
+import {
+  DataSheetProps,
+  DataViewCoreProps,
+  InitialDataChunk,
+} from "../types.ts";
+import {
+  loaderSeedAtoms,
+  resolveInitialData,
+  seededRows,
+} from "./loader-state.ts";
 import { DataPanelProps } from "../data-panel.ts";
 
 /** Create a Jotai scoped store */
@@ -153,16 +162,23 @@ export function useResolvedProvider<T>(props: {
 }
 
 function DataSheetStoreWrapper<T>(props: DataSheetProviderProps<T>) {
-  const { toaster, initialFilters, initialSorts, ...rest } = props;
+  const { toaster, initialFilters, initialSorts, initialData, ...rest } = props;
 
   // Initial view state is folded into the store's *creation*, not applied in an
   // effect: the loader mounts below this and its effects run first, so an
   // effect-applied filter would arrive after the first (unfiltered) fetch had
   // already gone out — and be immediately superseded. Creating the store with
   // the view already set means the first fetch is the right one.
+  //
+  // A seeded first window (`initialData`) is folded in the same way, for the
+  // same reason and one more: rows placed at creation are in the first render,
+  // so a server render carries them instead of the empty state the loader
+  // shows until its first (asynchronous) page resolves.
+  const seed = resolveInitialData(initialData);
   const initializeStore = (set: any, get: any) => ({
     ...createZustandStore<T>(set, get),
     ...initialViewState({ initialFilters, initialSorts }),
+    ...initialDataState(seed),
   });
 
   return h(
@@ -170,11 +186,19 @@ function DataSheetStoreWrapper<T>(props: DataSheetProviderProps<T>) {
     {
       ctx,
       initializeStore,
-      atoms: [[toasterAtom, toaster]],
+      atoms: [[toasterAtom, toaster], ...loaderSeedAtoms(initialData)],
       debugName: "DataSheetProvider",
     },
     h(DataSheetProviderInner, rest),
   );
+}
+
+/** The store's `data` for a seeded first window; nothing without a seed. */
+function initialDataState<T>(
+  seed: InitialDataChunk<T> | null,
+): Partial<DataSheetState<T>> {
+  if (seed == null) return {};
+  return { data: seededRows(seed) as T[] };
 }
 
 /** The store fields that carry a caller-supplied starting view. Absent props
@@ -225,12 +249,22 @@ type AnyDataSheetProps<T> =
 
 export function splitDataProviderProps<T>(props: AnyDataSheetProps<T>) {
   /** Split provided props based on provider's needs */
-  return splitProps<AnyDataSheetProps<T>, DataSheetProviderProps<T>>(
+  const [providerProps, rendererProps] = splitProps<
+    AnyDataSheetProps<T>,
+    DataSheetProviderProps<T>
+  >(
     props,
     dataProviderKeys
       .union(interactionOptionsKeys)
       .union(tableDataProviderKeys) as Set<keyof DataSheetProviderProps<T>>,
   );
+  // `initialData` goes to both sides: the provider creates the store seeded
+  // with it, and the loader takes it as the first window it needn't fetch.
+  const initialData = (props as { initialData?: any }).initialData;
+  if (initialData != null) {
+    providerProps.initialData = initialData;
+  }
+  return [providerProps, rendererProps] as const;
 }
 
 export function DataSheetProvider<T>(
@@ -272,7 +306,8 @@ export function DataSheetProviderInner<T>(
     identity,
   } = providerProps;
 
-  const { data, dataProvider } = useResolvedProvider<T>(providerProps);
+  const { data, dataProvider, isLocalProvider } =
+    useResolvedProvider<T>(providerProps);
 
   const initializeStore = ctx.useSet(initializeStoreAtom);
   const storeAPI = useStoreAPI<T>();
@@ -303,7 +338,15 @@ export function DataSheetProviderInner<T>(
   const baseSpec = staticSpec ?? generateColumnSpec(data, columnSpecOptions);
 
   useEffect(() => {
+    // The store's `data` is the loader's for any fetched source (and may hold a
+    // seeded first window from creation); only an in-memory `data` prop is
+    // placed here.
+    let localRows: Partial<DataSheetStore<T>> = {};
+    if (isLocalProvider) {
+      localRows = { data };
+    }
     initializeStore({
+      ...localRows,
       columnSpec: postprocessColumnSpec(baseSpec),
       // Suppress the loader's first-chunk auto-generation whenever the consumer
       // provided a spec at all — a function (derived later in `_DataSheet`) OR
@@ -314,7 +357,6 @@ export function DataSheetProviderInner<T>(
       deferColumnSpec: columnSpec != null,
       editable: interactionOptions.enableEditing,
       enableColumnReordering,
-      data,
       defaultColumnWidth,
       tableRef,
     });

--- a/packages/data-sheet/src/provider/loader-state.ts
+++ b/packages/data-sheet/src/provider/loader-state.ts
@@ -1,0 +1,82 @@
+/** The loader's core state and the seeding of a first window.
+ *
+ * Kept apart from the loader (`postgrest-table/data-loaders.ts`) so the
+ * provider can seed the store at creation without a circular import.
+ */
+import { atom } from "jotai";
+import type { AtomMap } from "@macrostrat/scoped-store";
+import type { FetchDataOptions, FetchMode, InitialDataChunk } from "../types.ts";
+
+export interface LazyLoaderStateCore<T> {
+  loading: boolean;
+  error: Error | null;
+  initialized: boolean;
+  /** Reported source length when known (null = unknown / not reported). */
+  totalCount: number | null;
+  /** Windowing style: infinite-scroll windows, or one fixed page at a time. */
+  fetchMode: FetchMode;
+  /** Rows per chunk/page. */
+  pageSize: number;
+}
+
+export const DEFAULT_LOADER_CORE: LazyLoaderStateCore<any> = {
+  loading: false,
+  error: null,
+  initialized: false,
+  totalCount: null,
+  fetchMode: "scroll",
+  pageSize: 100,
+};
+
+export const lazyLoaderCoreStateAtom =
+  atom<LazyLoaderStateCore<any>>(DEFAULT_LOADER_CORE);
+
+/** Normalize the two accepted `initialData` shapes (bare rows, or rows with a
+ * total) to one. An empty seed is treated as no seed — there'd be nothing to
+ * show and nothing saved. */
+export function resolveInitialData<T>(
+  initialData: FetchDataOptions<T>["initialData"],
+): InitialDataChunk<T> | null {
+  if (initialData == null) return null;
+  if (Array.isArray(initialData)) {
+    if (initialData.length === 0) return null;
+    return { rows: initialData };
+  }
+  if ((initialData.rows ?? []).length === 0) return null;
+  return initialData;
+}
+
+/** The data array for a seeded first window: the rows in place, pre-sized to
+ * the reported total (with `null` for the rows not yet loaded) so the scrollbar
+ * and the counter are right immediately. */
+export function seededRows<T>(seed: InitialDataChunk<T>): (T | null)[] {
+  const rows = seed.rows ?? [];
+  const size = Math.max(seed.totalCount ?? rows.length, rows.length);
+  const data: (T | null)[] = new Array(size).fill(null);
+  for (let i = 0; i < rows.length; i++) data[i] = rows[i];
+  return data;
+}
+
+/** The loader's core state for a seeded first window — the same shape as after
+ * a completed first fetch. `initialized` means the loader neither refetches the
+ * seeded window nor shows an empty state. */
+export function seededLoaderCore<T>(
+  seed: InitialDataChunk<T>,
+): LazyLoaderStateCore<T> {
+  return {
+    ...DEFAULT_LOADER_CORE,
+    initialized: true,
+    totalCount: seed.totalCount ?? null,
+  };
+}
+
+/** Scoped-store atoms that make a store start out seeded. The store's own
+ * `data` is seeded alongside (see `DataSheetStoreWrapper`). Empty when there is
+ * no seed. */
+export function loaderSeedAtoms<T>(
+  initialData: FetchDataOptions<T>["initialData"],
+): AtomMap {
+  const seed = resolveInitialData(initialData);
+  if (seed == null) return [];
+  return [[lazyLoaderCoreStateAtom, seededLoaderCore(seed)]];
+}

--- a/packages/data-sheet/src/provider/types.ts
+++ b/packages/data-sheet/src/provider/types.ts
@@ -6,7 +6,7 @@ import type {
 } from "@blueprintjs/table";
 import type { ColumnSpec, ColumnSpecOptions } from "./column-spec";
 import { OverlayToaster } from "@blueprintjs/core";
-import { DataViewCoreProps } from "../types";
+import { DataViewCoreProps, FetchDataOptions } from "../types";
 import { DataViewRendererType } from "./interactions.ts";
 
 /** A single column sort entry for client-side sorting.
@@ -251,6 +251,10 @@ export interface DataSheetStoreMain<T> extends DataSheetVals<T> {
 
 export type DataSheetProviderProps<T> = DataViewCoreProps<T> & {
   toaster?: OverlayToaster;
+  /** A first window of rows the caller already has (see `FetchDataOptions`).
+   * The provider creates the store seeded with it, so the rows are in the very
+   * first render — a server render included. */
+  initialData?: FetchDataOptions<T>["initialData"];
   viewType?: DataViewRendererType;
   children?: React.ReactNode;
 };

--- a/packages/data-sheet/stories/data-panel/initial-state.stories.ts
+++ b/packages/data-sheet/stories/data-panel/initial-state.stories.ts
@@ -24,7 +24,9 @@ import { useCallback, useState } from "react";
  *    Applying them in an effect instead — the only option before — meant the
  *    unfiltered first page always went out and was immediately superseded.
  *  - **`initialData`** seeds the first window from rows the caller already has,
- *    so a server-rendered page doesn't re-request what it just shipped.
+ *    so a server-rendered page doesn't re-request what it just shipped. The
+ *    store is created with the rows in place, so they are in the very first
+ *    render — a server render carries them rather than the empty state.
  *  - **`distinctValues`** on the provider (via `useDistinctValues`) lets a value
  *    picker offer only what the column actually holds — one small grouped query
  *    instead of paging the table to find out.


### PR DESCRIPTION
## @macrostrat/data-sheet 4.7.0 (minor)

- `initialData` now seeds the store at creation, so the first window is in the first render (server renders included) instead of arriving in an effect
- Provider-backed views no longer have their `data` reset by the provider's init effect; only an in-memory `data` prop is placed there

`column-creator` and `feedback-components` keep their existing `^4` ranges, so they are unaffected.

## Consumer follow-up

In `web`, after publish: `yarn up @macrostrat/data-sheet@^4.7.0`. The column list (`pages/columns/index`) already passes `initialData`, so its first page appears in the server-rendered HTML once this version is installed; no further change needed there.

**Merging this PR publishes to NPM.**