### PR TITLE
Release data-sheet@4.8.0

### DIFF
--- a/.changeset/crawlable-pages.md
+++ b/.changeset/crawlable-pages.md
@@ -1,8 +1,0 @@
----
-"@macrostrat/data-sheet": minor
----
-
-- Keyset cursor in the provider contract: `FetchDataParams.after`; `createLocalProvider` slices past it (`rowsAfter` exported)
-- `startAfter` starts a view after a row (seeded into the store, passed to the provider on every chunk, dropped on the first view change)
-- `pageLinks` renders a visually hidden `rel="next"` link after the loaded rows and a "Return to top" notice for a mid-list start, so a list is crawlable from its server-rendered HTML
-- Story: Data panel / Crawlable pages

--- a/.changeset/crawlable-pages.md
+++ b/.changeset/crawlable-pages.md
@@ -1,0 +1,8 @@
+---
+"@macrostrat/data-sheet": minor
+---
+
+- Keyset cursor in the provider contract: `FetchDataParams.after`; `createLocalProvider` slices past it (`rowsAfter` exported)
+- `startAfter` starts a view after a row (seeded into the store, passed to the provider on every chunk, dropped on the first view change)
+- `pageLinks` renders a visually hidden `rel="next"` link after the loaded rows and a "Return to top" notice for a mid-list start, so a list is crawlable from its server-rendered HTML
+- Story: Data panel / Crawlable pages

--- a/packages/data-sheet/CHANGELOG.md
+++ b/packages/data-sheet/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.8.0] - 2026-09-06 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-sheet-v4.7.0...@macrostrat/data-sheet-v4.8.0)
+
+### Minor Changes
+
+- - Keyset cursor in the provider contract: `FetchDataParams.after`;
+    `createLocalProvider` slices past it (`rowsAfter` exported)
+    [98e127f5](https://github.com/UW-Macrostrat/web-components/commit/98e127f51463a57bd2d1f93320a8d5e30c2cefdd)
+  - `startAfter` starts a view after a row (seeded into the store, passed to the
+    provider on every chunk, dropped on the first view change)
+  - `pageLinks` renders a visually hidden `rel="next"` link after the loaded
+    rows and a "Return to top" notice for a mid-list start, so a list is
+    crawlable from its server-rendered HTML
+  - Story: Data panel / Crawlable pages
+
 ## [4.7.0] - 2026-09-06 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-sheet-v4.6.0...@macrostrat/data-sheet-v4.7.0)
 
 ### Minor Changes

--- a/packages/data-sheet/package.json
+++ b/packages/data-sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/data-sheet",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Scalable data sheet with optional editing capabilities",
   "repository": {
     "type": "git",

--- a/packages/data-sheet/src/data-panel.module.sass
+++ b/packages/data-sheet/src/data-panel.module.sass
@@ -65,6 +65,31 @@
   align-items: center
   justify-content: center
 
+// Crawlable next-page link: in the HTML for crawlers, out of the way for
+// readers. Visually hidden rather than `display: none`, which crawlers may
+// discount.
+.crawl-next-link
+  position: absolute
+  width: 1px
+  height: 1px
+  overflow: hidden
+  clip-path: inset(50%)
+  white-space: nowrap
+
+// Heads the content while the view starts mid-list (a `?after=` page).
+.view-start-notice
+  flex: 0 0 auto
+  display: flex
+  align-items: center
+  justify-content: space-between
+  gap: var(--data-panel-item-gap, 8px)
+  padding: 6px 12px
+  margin-bottom: var(--data-panel-item-gap, 8px)
+  border-radius: 4px
+  background: var(--panel-background-color, rgba(128, 128, 128, 0.08))
+  color: var(--text-subtle, #738091)
+  font-size: 13px
+
 // Skeleton placeholder shown where a loading page's rows will land — sized like
 // a card so the body height stays stable (no blank flash, no footer ping). The
 // shimmer comes from Blueprint's `.bp6-skeleton`.

--- a/packages/data-sheet/src/data-panel.ts
+++ b/packages/data-sheet/src/data-panel.ts
@@ -35,7 +35,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { Classes, Icon, NonIdealState, Spinner } from "@blueprintjs/core";
+import {
+  AnchorButton,
+  Classes,
+  Icon,
+  NonIdealState,
+  Spinner,
+} from "@blueprintjs/core";
+import { startAfterAtom } from "./provider/loader-state.ts";
 import {
   anchorRefAtom,
   ctx,
@@ -205,6 +212,7 @@ export function DataPanelRenderer<T>({
   contentFooter,
   autoLoadPages,
   scrollBody,
+  pageLinks,
   className,
   toolbarStyle = DataPanelToolbarStyle.BORDERED,
   viewControls = "inline",
@@ -412,6 +420,45 @@ export function DataPanelRenderer<T>({
     contentFooter ?? defaultFooter,
   );
 
+  // Crawlable paging (see `PageLinks`). Both are plain links, so they work in
+  // the server-rendered HTML with no script: the next-page link is visually
+  // hidden after the loaded rows and points past the last loaded row; the
+  // "Return to top" notice heads the content while the view starts mid-list.
+  const startAfter = ctx.useValue(startAfterAtom);
+  const lastLoadedRow = useMemo(() => {
+    for (let i = data.length - 1; i >= 0; i--) {
+      if (data[i] != null) return data[i];
+    }
+    return null;
+  }, [data]);
+  // Gated on the counts rather than `hasMore`, which reads the resolved
+  // provider — synced after mount, so absent in a server render.
+  const moreToCome = total == null || loadedCount < total;
+  let nextPageLink: ReactNode = null;
+  if (pageLinks != null && lastLoadedRow != null && moreToCome) {
+    nextPageLink = h(
+      "a.crawl-next-link",
+      {
+        href: pageLinks.after(lastLoadedRow),
+        rel: "next",
+        tabIndex: -1,
+        "aria-hidden": true,
+      },
+      "Next page",
+    );
+  }
+  let viewStartNotice: ReactNode = null;
+  if (startAfter != null && pageLinks?.top != null) {
+    viewStartNotice = h("div.view-start-notice", [
+      h("span.view-start-text", `Continued after #${startAfter}`),
+      h(
+        AnchorButton,
+        { href: pageLinks.top, minimal: true, small: true, icon: "arrow-up" },
+        pageLinks.topLabel ?? "Return to top",
+      ),
+    ]);
+  }
+
   // Body + optional filter/detail sidebar share a horizontal row so each
   // scrolls independently.
 
@@ -461,7 +508,9 @@ export function DataPanelRenderer<T>({
           },
           [
             h("div.data-panel-body-content", [
+              viewStartNotice,
               emptyState ?? h(ScrollBody, { placeholders }, cards),
+              nextPageLink,
               _contentFooter,
             ]),
           ],

--- a/packages/data-sheet/src/postgrest-table/data-loaders.ts
+++ b/packages/data-sheet/src/postgrest-table/data-loaders.ts
@@ -27,6 +27,7 @@ import {
   lazyLoaderCoreStateAtom,
   resolveInitialData,
   seededRows,
+  startAfterAtom,
   type LazyLoaderStateCore,
 } from "../provider/loader-state.ts";
 
@@ -677,6 +678,10 @@ export function useDataLoader<T = any>(
   const page = ctx.useValue(chunkPageAtom);
   const setPage = ctx.useSet(chunkPageAtom);
   const refreshToken = ctx.useValue(dataRefreshTokenAtom);
+  // The keyset cursor of a view that starts mid-list. Seeded at store creation
+  // (`startAfter`); cleared below on the first view change, since it describes
+  // only the view it arrived with.
+  const [startAfter, setStartAfter] = ctx.use(startAfterAtom);
   const columnSorts = useSelector((s) => s.columnSorts);
   const activeFilters = useSelector((s) => s.activeFilters);
   const abortRef = useRef<AbortController | null>(null);
@@ -729,9 +734,16 @@ export function useDataLoader<T = any>(
   const seedRef = useRef(resolveInitialData(initialData));
   // Gate on the seed until it's actually in state (see the fetch effect).
   const awaitingSeedRef = useRef(seedRef.current != null);
+  const firstResetRef = useRef(true);
   useEffect(() => {
     const seed = seedRef.current;
     seedRef.current = null;
+    // A view change (not the mount) ends a mid-list start: the cursor only
+    // described the view it arrived with.
+    if (!firstResetRef.current) {
+      setStartAfter(null);
+    }
+    firstResetRef.current = false;
     if (seed != null) {
       if (!state.initialized) {
         dispatch({
@@ -798,6 +810,7 @@ export function useDataLoader<T = any>(
         sorts: columnSorts,
         filters,
         cursor,
+        after: startAfter,
       });
       if (controller.signal.aborted) return;
       const rows = result.rows ?? [];

--- a/packages/data-sheet/src/provider/core.ts
+++ b/packages/data-sheet/src/provider/core.ts
@@ -162,7 +162,14 @@ export function useResolvedProvider<T>(props: {
 }
 
 function DataSheetStoreWrapper<T>(props: DataSheetProviderProps<T>) {
-  const { toaster, initialFilters, initialSorts, initialData, ...rest } = props;
+  const {
+    toaster,
+    initialFilters,
+    initialSorts,
+    initialData,
+    startAfter,
+    ...rest
+  } = props;
 
   // Initial view state is folded into the store's *creation*, not applied in an
   // effect: the loader mounts below this and its effects run first, so an
@@ -186,7 +193,10 @@ function DataSheetStoreWrapper<T>(props: DataSheetProviderProps<T>) {
     {
       ctx,
       initializeStore,
-      atoms: [[toasterAtom, toaster], ...loaderSeedAtoms(initialData)],
+      atoms: [
+        [toasterAtom, toaster],
+        ...loaderSeedAtoms(initialData, startAfter),
+      ],
       debugName: "DataSheetProvider",
     },
     h(DataSheetProviderInner, rest),
@@ -258,11 +268,18 @@ export function splitDataProviderProps<T>(props: AnyDataSheetProps<T>) {
       .union(interactionOptionsKeys)
       .union(tableDataProviderKeys) as Set<keyof DataSheetProviderProps<T>>,
   );
-  // `initialData` goes to both sides: the provider creates the store seeded
-  // with it, and the loader takes it as the first window it needn't fetch.
-  const initialData = (props as { initialData?: any }).initialData;
+  // `initialData` and `startAfter` go to both sides: the provider creates the
+  // store seeded with them, and the loader takes them as the first window it
+  // needn't fetch and the cursor its chunks are counted from.
+  const { initialData, startAfter } = props as {
+    initialData?: any;
+    startAfter?: string | number | null;
+  };
   if (initialData != null) {
     providerProps.initialData = initialData;
+  }
+  if (startAfter != null) {
+    providerProps.startAfter = startAfter;
   }
   return [providerProps, rendererProps] as const;
 }

--- a/packages/data-sheet/src/provider/loader-state.ts
+++ b/packages/data-sheet/src/provider/loader-state.ts
@@ -70,13 +70,26 @@ export function seededLoaderCore<T>(
   };
 }
 
+/** The identity of the row the current view starts after (`startAfter`), or
+ * `null` for a view that starts at the top. Set at store creation so a server
+ * render shows the "Return to top" link; the loader clears it on the first view
+ * change. */
+export const startAfterAtom = atom<string | number | null>(null);
+
 /** Scoped-store atoms that make a store start out seeded. The store's own
  * `data` is seeded alongside (see `DataSheetStoreWrapper`). Empty when there is
  * no seed. */
 export function loaderSeedAtoms<T>(
   initialData: FetchDataOptions<T>["initialData"],
+  startAfter: FetchDataOptions<T>["startAfter"] = null,
 ): AtomMap {
+  const atoms: AtomMap = [];
+  if (startAfter != null) {
+    atoms.push([startAfterAtom, startAfter]);
+  }
   const seed = resolveInitialData(initialData);
-  if (seed == null) return [];
-  return [[lazyLoaderCoreStateAtom, seededLoaderCore(seed)]];
+  if (seed != null) {
+    atoms.push([lazyLoaderCoreStateAtom, seededLoaderCore(seed)]);
+  }
+  return atoms;
 }

--- a/packages/data-sheet/src/provider/table-data.ts
+++ b/packages/data-sheet/src/provider/table-data.ts
@@ -32,6 +32,12 @@ export interface FetchDataParams {
    * sources can page from this cursor (e.g. `WHERE key > cursor`) instead of a
    * slow `OFFSET`; offset-based sources can ignore it. */
   cursor?: { row: any; index: number } | null;
+  /** Identity of the row the view is counted from: `offset` 0 is the first
+   * row *after* it. Set while a view starts mid-list (see `startAfter` in
+   * `FetchDataOptions`); absent or `null` when it starts at the top. Keyset
+   * sources translate it to `WHERE key > after`; the local provider slices past
+   * the row. `totalCount` then reports the rows after it. */
+  after?: string | number | null;
 }
 
 /** Result of a `fetchChunk` call. `totalCount` reports the source length when
@@ -125,7 +131,7 @@ export function createLocalProvider<T = any>(
 
   return {
     identity,
-    async fetchData({ offset, limit, sorts, filters }) {
+    async fetchData({ offset, limit, sorts, filters, after }) {
       let rows = data;
       if (filters != null && filters.length > 0) {
         rows = rows.filter((row) =>
@@ -137,6 +143,7 @@ export function createLocalProvider<T = any>(
       if (sorts != null && sorts.length > 0) {
         rows = [...rows].sort(compareRowsBySorts(sorts));
       }
+      rows = rowsAfter(rows, after, identity);
       return {
         rows: rows.slice(offset, offset + limit),
         totalCount: rows.length,
@@ -146,6 +153,21 @@ export function createLocalProvider<T = any>(
       return distinctValuesOf(data, columnKey, opts);
     },
   };
+}
+
+/** The rows past the one with identity `after` in the (filtered, sorted) view;
+ * the whole view when `after` is absent or names no row. Identities are compared
+ * as strings, since a cursor read from a URL arrives as one. */
+export function rowsAfter<T>(
+  rows: T[],
+  after: string | number | null | undefined,
+  identity: (row: T) => string | number | null | undefined,
+): T[] {
+  if (after == null) return rows;
+  const key = String(after);
+  const index = rows.findIndex((row) => String(identity(row)) === key);
+  if (index < 0) return rows;
+  return rows.slice(index + 1);
 }
 
 // Stable synthetic identity for in-memory rows lacking a natural `id`. Keyed by

--- a/packages/data-sheet/src/provider/types.ts
+++ b/packages/data-sheet/src/provider/types.ts
@@ -255,6 +255,9 @@ export type DataSheetProviderProps<T> = DataViewCoreProps<T> & {
    * The provider creates the store seeded with it, so the rows are in the very
    * first render — a server render included. */
   initialData?: FetchDataOptions<T>["initialData"];
+  /** The row the view starts after (see `FetchDataOptions`). Seeded into the
+   * store at creation alongside `initialData`. */
+  startAfter?: FetchDataOptions<T>["startAfter"];
   viewType?: DataViewRendererType;
   children?: React.ReactNode;
 };

--- a/packages/data-sheet/src/types.ts
+++ b/packages/data-sheet/src/types.ts
@@ -39,6 +39,14 @@ export interface FetchDataOptions<T = any> {
    * Pass `totalCount` when it's known — the array is pre-sized to it, so the
    * scrollbar and the counter are right from the first paint. */
   initialData?: T[] | InitialDataChunk<T>;
+  /** Identity of the row the view starts after — the keyset cursor of a view
+   * that begins mid-list, as reached through a page link (`?after=<id>`). It is
+   * passed to the provider as `after` on every chunk of the view it was created
+   * for, and dropped on the first view change (sorts, filters, a refresh), since
+   * it only describes that view. Read from the URL when the page loads; the
+   * client never writes it back while scrolling. Pair it with an `initialData`
+   * seed of the rows after it for a complete server render. */
+  startAfter?: string | number | null;
   /** Debounce (ms) applied to view-state → refetch, so rapid changes (typing a
    * text filter) collapse into one fetch once the view settles. The input stays
    * instant; only the fetch waits. `0` (default) keeps immediate refetching. */
@@ -88,8 +96,26 @@ export interface DataViewCoreProps<T> extends InteractionOptions {
   initialSorts?: ColumnSort[];
 }
 
+/** Links that make a paged view reachable without JavaScript. */
+export interface PageLinks<T = any> {
+  /** The href of the view that starts after `row` (`?after=<id>`). Rendered as
+   * a visually hidden `rel="next"` link after the loaded rows, so a crawler
+   * following the server-rendered HTML reaches every page of the list while
+   * readers keep the infinite scroll. */
+  after: (row: T) => string;
+  /** The href of the view's first page. Shown as a "Return to top" link at the
+   * head of the content while the view starts mid-list (`startAfter`). */
+  top?: string;
+  /** Label for that link (default "Return to top"). */
+  topLabel?: ReactNode;
+}
+
 export interface DataViewSharedProps<T = any>
   extends FetchDataOptions<T>, DataViewCoreProps<T> {
+  /** Crawlable page links (see `PageLinks`). Neither link is written to the
+   * browser's URL as the list is scrolled — deep pages are for crawlers and
+   * for whoever follows such a link, not a state the page keeps. */
+  pageLinks?: PageLinks<T>;
   /** Configurable table actions shown in a selection-aware toolbar.
    * When provided, the actions toolbar renders alongside the existing
    * edit toolbar. Actions are filtered by the current selection cardinality. */

--- a/packages/data-sheet/stories/data-panel/crawlable-pages.stories.ts
+++ b/packages/data-sheet/stories/data-panel/crawlable-pages.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import h from "@macrostrat/hyper";
+import { createLocalProvider, DataPanel, rowsAfter } from "../../src";
+import { ALL, container, fullSpec, Sample, SampleCard } from "./utils.ts";
+
+/**
+ * An infinite-scrolling list that a crawler can still walk page by page.
+ *
+ * Two props, both plain links so they work in server-rendered HTML with no
+ * script:
+ *
+ *  - **`pageLinks.after(row)`** — the href of the view that starts after a row.
+ *    The panel renders it as a visually hidden `rel="next"` link after the
+ *    loaded rows, so a crawler following the HTML reaches every page while
+ *    readers keep the infinite scroll. It is never written to the browser's
+ *    URL as the list is scrolled.
+ *  - **`startAfter`** — the row identity a view begins after (read from
+ *    `?after=` when the page loads). The provider receives it as `after` on
+ *    every chunk of that view; the local provider slices past the row, a keyset
+ *    source would add `WHERE key > after`. With **`pageLinks.top`** set, a
+ *    "Return to top" notice heads the content. The first view change (a sort,
+ *    a filter, a refresh) drops the cursor, since it only described that view.
+ *
+ * Seed the rows after the cursor as `initialData` and the whole page — rows,
+ * notice, next link — is complete in the server render.
+ *
+ * The next link is hidden by design; these stories reveal it (dashed outline)
+ * so the target can be read.
+ */
+const meta: Meta<any> = {
+  title: "Data sheet/Data panel/Crawlable pages",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+const PAGE_SIZE = 20;
+const identity = (row: Sample) => row.id;
+const provider = createLocalProvider(ALL, { identity });
+
+const pageLinks = {
+  after: (row: Sample) => `?after=${row.id}`,
+  top: "?",
+};
+
+/** Story-only: make the hidden next link visible. */
+const reveal = h("style", {}, `
+  a[rel="next"] {
+    position: static !important; width: auto !important; height: auto !important;
+    clip-path: none !important; overflow: visible !important;
+    display: inline-block; margin: 8px 0; padding: 4px 8px;
+    border: 1px dashed currentColor; border-radius: 4px; font-size: 12px;
+  }
+  a[rel="next"]::after { content: " → " attr(href); opacity: 0.7; }
+`);
+
+function CrawlablePanel({ startAfter }: { startAfter: number | null }) {
+  // What a server would do for `?after=<id>`: seed the first page after it.
+  const rows = rowsAfter(ALL, startAfter, identity);
+  const initialData = { rows: rows.slice(0, PAGE_SIZE), totalCount: rows.length };
+  return container(
+    h([
+      reveal,
+      h(DataPanel<Sample>, {
+        name: "Samples",
+        itemLabel: "sample",
+        provider,
+        columnSpec: fullSpec,
+        itemComponent: SampleCard,
+        pageSize: PAGE_SIZE,
+        autoLoadPages: 1,
+        initialData,
+        startAfter,
+        pageLinks,
+      }),
+    ]),
+  );
+}
+
+/** The first page: no notice; the hidden next link points after row 20. */
+export const FirstPage: StoryObj = {
+  render: () => h(CrawlablePanel, { startAfter: null }),
+};
+
+/** A deep page reached through a link (`?after=60`): the list is continued
+ * after that row, the notice offers "Return to top", and the next link points
+ * after row 80. Change a sort or filter and the cursor is dropped. */
+export const DeepPage: StoryObj = {
+  render: () => h(CrawlablePanel, { startAfter: 60 }),
+};


### PR DESCRIPTION
## @macrostrat/data-sheet 4.8.0 (minor)

- Keyset cursor in the provider contract: `FetchDataParams.after`; `createLocalProvider` slices past it (`rowsAfter` exported)
- `startAfter` starts a view after a row (seeded into the store, passed to the provider on every chunk, dropped on the first view change)
- `pageLinks` renders a visually hidden `rel="next"` link after the loaded rows and a "Return to top" notice for a mid-list start, so a list is crawlable from its server-rendered HTML
- Story: Data panel / Crawlable pages

Dependents keep their `workspace:^` ranges and are unaffected.

## Consumer follow-up

In `web`, after publish: `yarn up @macrostrat/data-sheet@^4.8.0`. The column list (`pages/columns/index`) already passes `startAfter` and `pageLinks`, so `?after=<col_id>` pages gain their "Return to top" notice and hidden next link as soon as this version is installed; no further change needed there.

**Merging this PR publishes to NPM.**