### PR TITLE
Release @macrostrat/data-provider@1.2.1

### DIFF
--- a/.changeset/point-column-geometry.md
+++ b/.changeset/point-column-geometry.md
@@ -1,0 +1,8 @@
+---
+"@macrostrat/data-provider": patch
+---
+
+Don't mangle point column geometries in `convertSmallAreasToPoints`. Point-located
+columns (`col_type = 'section'`) have zero area, so they passed the zero-area test
+and were rewritten as `{ type: "Point", coordinates: undefined }`, crashing any
+consumer that streams the geometry.

--- a/.changeset/point-column-geometry.md
+++ b/.changeset/point-column-geometry.md
@@ -1,8 +1,0 @@
----
-"@macrostrat/data-provider": patch
----
-
-Don't mangle point column geometries in `convertSmallAreasToPoints`. Point-located
-columns (`col_type = 'section'`) have zero area, so they passed the zero-area test
-and were rewritten as `{ type: "Point", coordinates: undefined }`, crashing any
-consumer that streams the geometry.

--- a/packages/data-provider/CHANGELOG.md
+++ b/packages/data-provider/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.2.1] - 2026-09-10 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-provider-v1.2.0...@macrostrat/data-provider-v1.2.1)
+
+### Patch Changes
+
+- Don't mangle point column geometries in `convertSmallAreasToPoints`.
+  Point-located
+  [39d6dba1](https://github.com/UW-Macrostrat/web-components/commit/39d6dba11383f8cbd9657a459c4e48003e152fac)
+  columns (`col_type = 'section'`) have zero area, so they passed the zero-area
+  test and were rewritten as `{ type: "Point", coordinates: undefined }`,
+  crashing any consumer that streams the geometry.
+
 ## [1.2.0] - 2026-07-30 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/data-provider-v1.1.0...@macrostrat/data-provider-v1.2.0)
 
 ### Minor Changes

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/data-provider",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Data views for Macrostrat stratigraphic columns",
   "repository": {
     "type": "git",

--- a/packages/data-provider/src/fetch.ts
+++ b/packages/data-provider/src/fetch.ts
@@ -127,6 +127,15 @@ function removeFeaturesWithoutGeometry(features) {
 
 function convertSmallAreasToPoints(features) {
   return features.map((f) => {
+    // Point-located columns (`col_type = 'section'`) arrive from the API as
+    // Points already, and there is no area to collapse. Without this guard the
+    // zero-area test below passes and the ring indexing produces
+    // `{ type: "Point", coordinates: undefined }`, which crashes anything that
+    // streams the geometry — `geoCentroid` in the keyboard-navigation
+    // triangulation, for one.
+    if (f.geometry.type === "Point" || f.geometry.type === "MultiPoint") {
+      return f;
+    }
     // GeoArea takes a long time to run. We are really more worried about points that are zero-area
     if (geoArea(f.geometry) < 1e-8) {
       const centroid = f.geometry.coordinates[0][0];


### PR DESCRIPTION
## `@macrostrat/data-provider` 1.2.1

Fixes a crash that takes down the `/columns` browse map for any project whose
columns are point-located.

`convertSmallAreasToPoints` collapses degenerate zero-area polygons into points,
but never checked the geometry type. A **Point** has zero area, so it passed the
test — and `coordinates[0][0]` on a Point indexes into a number
(`111.4333[0]` → `undefined`), rewriting the geometry as
`{ type: "Point", coordinates: undefined }`. That crashes anything that streams
it; `geoCentroid` in the keyboard-navigation triangulation is the first thing to
hit it:

```
TypeError: can't access property 0 of undefined
    Point stream.js:23
    ...
    buildTriangulation keyboard-navigation.ts:55
```

The function was simply never reached with a Point before. `/columns` began
serving point geometry for columns with no `col_areas` polygon
(macrostrat-api 2.3.10), which made 28,951 GBDB columns arrive as Points.

### Changelog

- Don't mangle point column geometries in `convertSmallAreasToPoints`.
  Point-located columns (`col_type = 'section'`) have zero area, so they passed
  the zero-area test and were rewritten as
  `{ type: "Point", coordinates: undefined }`, crashing any consumer that
  streams the geometry.

### Verification

`geoArea`/`geoCentroid` exercised directly against d3-geo 3.1.1 with real GBDB
coordinates, reproducing the reported error and confirming the guard clears it.
`yarn run check-types` clean; `yarn run build` exit 0 with the guard present in
`dist/fetch.js` and `dist/fetch.cjs`.

No Storybook story covers this path — the crash needs point geometries flowing
through `data-provider` into the keyboard-navigation triangulation, which is why
it surfaced as a runtime error rather than in review.

### Pairs with

- `UW-Macrostrat/macrostrat-api` 2.3.10 — serves `cols.coordinate` for
  `/columns` geometry when a column has no `col_areas` polygon. Already on
  `main` there; this side is only needed because that one landed.

### Consumer follow-up

`Code/web` moves `@macrostrat/data-provider` to `^1.2.1`. Dependents
(`column-views`, `map-views`, `timescale`) use `workspace:^` and did not need a
bump — their published ranges already admit 1.2.1, so they pick up the fix
through resolution.
